### PR TITLE
Fix CI failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,9 +113,6 @@ jobs:
       fail-fast: false
       matrix:
         py_version:
-          - name: '3.8'
-            tox_env: integration-py38
-
           - name: '3.9'
             tox_env: integration-py39
 
@@ -167,9 +164,6 @@ jobs:
       fail-fast: false
       matrix:
         py_version:
-          - name: '3.8'
-            tox_env: unit-py38
-
           - name: '3.9'
             tox_env: unit-py39
 

--- a/ansible_builder/__main__.py
+++ b/ansible_builder/__main__.py
@@ -2,4 +2,3 @@ from . import cli
 
 if __name__ == '__main__':
     cli.run()
-

--- a/ansible_builder/_target_scripts/introspect.py
+++ b/ansible_builder/_target_scripts/introspect.py
@@ -295,6 +295,7 @@ def create_introspect_parser(parser):
 
     return introspect_parser
 
+
 EXCLUDE_REQUIREMENTS = frozenset((
     # obviously already satisfied or unwanted
     'ansible', 'ansible-base', 'python', 'ansible-core',
@@ -383,7 +384,6 @@ def write_file(filename: str, lines: list) -> bool:
     with open(filename, 'w') as f:
         f.write(new_text)
     return True
-
 
 
 def main():

--- a/ansible_builder/cli.py
+++ b/ansible_builder/cli.py
@@ -36,7 +36,7 @@ def run():
             sys.exit(1)
 
     elif args.action == 'introspect':
-        run_introspect()
+        run_introspect(args, logger)
 
     logger.error("An error has occured.")
     sys.exit(1)

--- a/ansible_builder/cli.py
+++ b/ansible_builder/cli.py
@@ -10,8 +10,8 @@ from .colors import MessageColors
 from .exceptions import DefinitionError
 from .main import AnsibleBuilder
 from .policies import PolicyChoices
-from ._target_scripts.introspect import create_introspect_parser, run_introspect, process, simple_combine, base_collections_path
-from .utils import configure_logger, write_file
+from ._target_scripts.introspect import create_introspect_parser, run_introspect
+from .utils import configure_logger
 
 
 logger = logging.getLogger(__name__)

--- a/ansible_builder/user_definition.py
+++ b/ansible_builder/user_definition.py
@@ -23,6 +23,7 @@ ALLOWED_KEYS_V2 = [
 # HACK: manage lifetimes more carefully
 _tempfiles: list[tempfile.TemporaryFile] = []
 
+
 class ImageDescription:
     """
     Class to describe a container image from the EE file.
@@ -229,7 +230,6 @@ class UserDefinition:
 
             # Must set these values so that Containerfile uses the proper images
             self.build_arg_defaults['EE_BASE_IMAGE'] = self.base_image.name
-
 
     def _validate_v1(self):
         """

--- a/ansible_builder/user_definition.py
+++ b/ansible_builder/user_definition.py
@@ -21,7 +21,7 @@ ALLOWED_KEYS_V2 = [
 
 
 # HACK: manage lifetimes more carefully
-_tempfiles: list[tempfile.TemporaryFile] = []
+_tempfiles: list[type[tempfile.TemporaryFile]] = []
 
 
 class ImageDescription:

--- a/demo/v3_demo/execution-environment.yml
+++ b/demo/v3_demo/execution-environment.yml
@@ -4,9 +4,9 @@ version: 3
 images:
   base_image:
     name: quay.io/centos/centos:stream8  # vanilla image!
-    #name: quay.io/centos/centos:stream9  # vanilla image!
-    #name: registry.fedoraproject.org/fedora:36  # vanilla image!
-    #name: registry.access.redhat.com/ubi9/ubi:latest  # vanilla image!
+    # name: quay.io/centos/centos:stream9  # vanilla image!
+    # name: registry.fedoraproject.org/fedora:36  # vanilla image!
+    # name: registry.access.redhat.com/ubi9/ubi:latest  # vanilla image!
 
 # no longer required, we do the needful inline, but should still work if someone sets it
 #  builder_image:
@@ -17,9 +17,9 @@ dependencies:
     package_name: python39
     python_path: /usr/bin/python3.9
 
-  ansible_core: https://github.com/ansible/ansible/archive/refs/tags/v2.13.2.tar.gz # install from a GH ref tarball
+  ansible_core: https://github.com/ansible/ansible/archive/refs/tags/v2.13.2.tar.gz   # install from a GH ref tarball
 
-  ansible_runner: ansible-runner==2.2.1 # install from PyPI
+  ansible_runner: ansible-runner==2.2.1   # install from PyPI
 
   # FIXME: inline splat-as-string sucks, make separate keys for collections and roles
   galaxy: |

--- a/test/unit/test_introspect.py
+++ b/test/unit/test_introspect.py
@@ -1,6 +1,6 @@
 import os
 
-from ansible_builder.target_scripts.introspect import process, process_collection, simple_combine
+from ansible_builder._target_scripts.introspect import process, process_collection, simple_combine
 from ansible_builder.requirements import sanitize_requirements
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ commands =
     yamllint --version
     yamllint -s .
 
-[testenv:unit{,-py38,-py39,-py310}]
+[testenv:unit{,-py39,-py310}]
 description = Run unit tests
 commands = pytest {posargs:test/unit}
 
@@ -27,7 +27,7 @@ commands = pytest {posargs:test/unit}
 description = Run pulp integration tests
 commands = pytest -n 1 -m "serial" {posargs:test/pulp_integration}
 
-[testenv:integration{,-py38,-py39,-py310}]
+[testenv:integration{,-py39,-py310}]
 description = Run integration tests
 # rootless podman reads $HOME
 passenv =


### PR DESCRIPTION
- Fixes linting, unit and integration test errors.
- Removes Python 3.8 tests (assuming minimum of Python 3.9 moving forward). The use of `type[]` in `user_definition.py` needs >=3.9.
- Creates the `/output/scripts` directory in the `base` image and copies the local scripts from context dir to this location during setup of this image as later steps assume these as pre-existing (one of the causes of integration test failures).