### PR TITLE
WIP: Use voluptuous for EE schema validation

### DIFF
--- a/ansible_builder/ee_schema.py
+++ b/ansible_builder/ee_schema.py
@@ -1,0 +1,99 @@
+from voluptuous import Schema, Coerce, Required, Invalid
+
+from ansible_builder.exceptions import DefinitionError
+
+
+def _str_or_list():
+    """
+    Schema validation function for types that may be either a `str` or a `list`.
+    """
+    def f(v):
+        if type(v) != str and type(v) != list:
+            raise Invalid('expected str or list')
+    return f
+
+
+############
+# Version 1
+############
+
+schema_v1 = Schema({
+    "version": Required(Coerce(int), default=1),
+
+    "build_arg_defaults": {
+        "EE_BASE_IMAGE": str,
+        "EE_BUILDER_IMAGE": str,
+        "ANSIBLE_GALAXY_CLI_COLLECTION_OPTS": str,
+    },
+
+    "ansible_config": str,
+
+    "dependencies": {
+        "python": str,
+        "galaxy": str,
+        "system": str,
+    },
+
+    "additional_build_steps": {
+        "prepend": _str_or_list(),
+        "append": _str_or_list(),
+    },
+})
+
+
+############
+# Version 2
+############
+
+schema_v2 = Schema({
+    "version": Required(Coerce(int, msg="'version' must be an integer")),
+
+    "build_arg_defaults": {
+        "ANSIBLE_GALAXY_CLI_COLLECTION_OPTS": str,
+    },
+
+    "ansible_config": str,
+
+    "dependencies": {
+        "python": str,
+        "galaxy": str,
+        "system": str,
+    },
+
+    "additional_build_steps": {
+        "prepend": _str_or_list(),
+        "append": _str_or_list(),
+    },
+
+    "images": {
+        "base_image": {
+            "name": str,
+            "signature_original_name": str,
+        },
+        "builder_image": {
+            "name": str,
+            "signature_original_name": str,
+        },
+    },
+})
+
+
+def validate_schema(ee_def):
+    schema_version = 1
+    if 'version' in ee_def:
+        try:
+            schema_version = int(ee_def['version'])
+        except ValueError:
+            raise DefinitionError(f"Schema version not an integer: {ee_def['version']}")
+
+    if schema_version not in (1, 2):
+        raise DefinitionError(f"Unsupported schema version: {schema_version}")
+
+    try:
+        if schema_version == 1:
+            schema_v1(ee_def)
+        elif schema_version == 2:
+            schema_v2(ee_def)
+    except Invalid as e:
+        msg = str(e)
+        raise DefinitionError(msg=msg, path=e.path)

--- a/ansible_builder/exceptions.py
+++ b/ansible_builder/exceptions.py
@@ -5,6 +5,7 @@ class DefinitionError(RuntimeError):
     # Eliminate the output of traceback before our custom error message prints out
     sys.tracebacklimit = 0
 
-    def __init__(self, msg):
+    def __init__(self, msg, path=None):
         super(DefinitionError, self).__init__("%s" % msg)
         self.msg = msg
+        self.path = path

--- a/ansible_builder/main.py
+++ b/ansible_builder/main.py
@@ -89,7 +89,7 @@ class AnsibleBuilder:
         resolved_keyring = None
 
         if policy is not None:
-            if self.version != "2":
+            if self.version != 2:
                 raise ValueError(f'--container-policy not valid with version {self.version} format')
 
             # Require podman runtime

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 PyYAML
 requirements-parser
 bindep
+voluptuous

--- a/test/unit/test_main.py
+++ b/test/unit/test_main.py
@@ -10,13 +10,13 @@ from ansible_builder.main import AnsibleBuilder
 def test_definition_version(exec_env_definition_file):
     path = exec_env_definition_file(content={'version': 1})
     aee = AnsibleBuilder(filename=path)
-    assert aee.version == '1'
+    assert aee.version == 1
 
 
 def test_definition_version_missing(exec_env_definition_file):
     path = exec_env_definition_file(content={})
     aee = AnsibleBuilder(filename=path)
-    assert aee.version == '1'
+    assert aee.version == 1
 
 
 @pytest.mark.parametrize('path_spec', ('absolute', 'relative'))
@@ -92,7 +92,7 @@ def test_build_command(exec_env_definition_file, runtime):
     content = {'version': 1}
     path = exec_env_definition_file(content=content)
 
-    aee = AnsibleBuilder(filename=path, tag='my-custom-image')
+    aee = AnsibleBuilder(filename=path, tag=['my-custom-image'])
     command = aee.build_command
     assert 'build' and 'my-custom-image' in command
 
@@ -100,7 +100,8 @@ def test_build_command(exec_env_definition_file, runtime):
 
     command = aee.build_command
     assert 'foo/bar/path' in command
-    assert 'foo/bar/path/Dockerfile' in " ".join(command)
+    fpath = 'foo/bar/path/' + constants.runtime_files[runtime]
+    assert fpath in " ".join(command)
 
 
 def test_nested_galaxy_file(data_dir, tmp_path):

--- a/test/unit/test_user_definition.py
+++ b/test/unit/test_user_definition.py
@@ -24,41 +24,39 @@ class TestUserDefinition:
         ),  # missing file
         (
             "{'version': 1, 'additional_build_steps': 'RUN me'}",
-            "Expected 'additional_build_steps' in the provided definition file to be a dictionary\n"
-            "with keys 'prepend' and/or 'append'; found a str instead."
+            "expected a dictionary"
         ),  # not right format for additional_build_steps
         (
             "{'version': 1, 'additional_build_steps': {'middle': 'RUN me'}}",
-            "Keys ('middle',) are not allowed in 'additional_build_steps'."
+            "extra keys not allowed"
         ),  # there are no "middle" build steps
         (
             "{'version': 1, 'build_arg_defaults': {'EE_BASE_IMAGE': ['foo']}}",
-            "Expected build_arg_defaults.EE_BASE_IMAGE to be a string; Found a <class 'list'> instead."
+            "expected str for dictionary value"
         ),  # image itself is wrong type
         (
             "{'version': 1, 'build_arg_defaults': {'BUILD_ARRRRRG': 'swashbuckler'}}",
-            "Keys {'BUILD_ARRRRRG'} are not allowed in 'build_arg_defaults'."
+            "extra keys not allowed"
         ),  # image itself is wrong type
         (
             "{'version': 1, 'ansible_config': ['ansible.cfg']}",
-            "Expected 'ansible_config' in the provided definition file to\n"
-            "be a string; found a list instead."
+            "expected str for dictionary value"
         ),
         (
             "{'version': 1, 'images': 'bar'}",
-            "Error: Unknown yaml key(s), {'images'}, found in the definition file."
+            "extra keys not allowed"
         ),
         (
             "{'version': 2, 'foo': 'bar'}",
-            "Error: Unknown yaml key(s), {'foo'}, found in the definition file."
+            "extra keys not allowed"
         ),
         (
             "{'version': 2, 'build_arg_defaults': {'EE_BASE_IMAGE': 'foo'}, 'images': {}}",
-            "Error: Version 2 does not allow defining EE_BASE_IMAGE or EE_BUILDER_IMAGE in 'build_arg_defaults'"
+            "extra keys not allowed"
         ),  # v1 base image defined in v2 file
         (
             "{'version': 2, 'build_arg_defaults': {'EE_BUILDER_IMAGE': 'foo'}, 'images': {}}",
-            "Error: Version 2 does not allow defining EE_BASE_IMAGE or EE_BUILDER_IMAGE in 'build_arg_defaults'"
+            "extra keys not allowed"
         ),  # v1 builder image defined in v2 file
     ], ids=[
         'integer', 'missing_file', 'additional_steps_format', 'additional_unknown',
@@ -88,7 +86,7 @@ class TestUserDefinition:
         path = exec_env_definition_file("{'version': 1, 'bad_key': 1}")
         with pytest.raises(DefinitionError) as error:
             AnsibleBuilder(filename=path)
-        assert "Error: Unknown yaml key(s), {'bad_key'}, found in the definition file." in str(error.value.args[0])
+        assert "extra keys not allowed" in str(error.value.args[0])
 
     def test_ee_missing_image_name(self, exec_env_definition_file):
         path = exec_env_definition_file("{'version': 2, 'images': { 'base_image': {'signature_original_name': ''}}}")


### PR DESCRIPTION
- Uses `voluptuous` to validate EE file during load.
- Custom EE schema validation error messages changed to more generic schema errors (as supplied by `voluptuous`). Less detailed, but reduces custom code overhead a great deal.
- EE version specifier now treated as an `int` instead of `str`.