### PR TITLE
Use jsonschema for EE schema validation

### DIFF
--- a/ansible_builder/ee_schema.py
+++ b/ansible_builder/ee_schema.py
@@ -1,0 +1,184 @@
+from jsonschema import validate, SchemaError, ValidationError
+
+from ansible_builder.exceptions import DefinitionError
+
+
+############
+# Version 1
+############
+
+schema_v1 = {
+    "type": "object",
+    "additionalProperties": False,
+    "properties": {
+        "version": {
+            "description": "The EE schema version number",
+            "type": "number",
+        },
+
+        "ansible_config": {
+            "type": "string",
+        },
+
+        "build_arg_defaults": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "EE_BASE_IMAGE": {
+                    "type": "string",
+                },
+                "EE_BUILDER_IMAGE": {
+                    "type": "string",
+                },
+                "ANSIBLE_GALAXY_CLI_COLLECTION_OPTS": {
+                    "type": "string",
+                },
+            },
+        },
+
+        "dependencies": {
+            "description": "The dependency stuff",
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "python": {
+                    "description": "The python dependency file",
+                    "type": "string",
+                },
+                "galaxy": {
+                    "description": "The Galaxy dependency file",
+                    "type": "string",
+                },
+                "system": {
+                    "description": "The system dependency file",
+                    "type": "string",
+                },
+            },
+        },
+
+        "additional_build_steps": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "prepend": {
+                    "anyOf": [{"type": "string"}, {"type": "array"}],
+                },
+                "append": {
+                    "anyOf": [{"type": "string"}, {"type": "array"}],
+                },
+            },
+        },
+    },
+}
+
+
+############
+# Version 2
+############
+
+schema_v2 = {
+    "type": "object",
+    "additionalProperties": False,
+    "properties": {
+        "version": {
+            "description": "The EE schema version number",
+            "type": "number",
+        },
+
+        "ansible_config": {
+            "type": "string",
+        },
+
+        "build_arg_defaults": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "ANSIBLE_GALAXY_CLI_COLLECTION_OPTS": {
+                    "type": "string",
+                },
+            },
+        },
+
+        "dependencies": {
+            "description": "The dependency stuff",
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "python": {
+                    "description": "The python dependency file",
+                    "type": "string",
+                },
+                "galaxy": {
+                    "description": "The Galaxy dependency file",
+                    "type": "string",
+                },
+                "system": {
+                    "description": "The system dependency file",
+                    "type": "string",
+                },
+            },
+        },
+
+        "images": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "base_image": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                        },
+                        "signature_original_name": {
+                            "type": "string",
+                        },
+                    },
+                },
+                "builder_image": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                        },
+                        "signature_original_name": {
+                            "type": "string",
+                        },
+                    },
+                }
+            },
+        },
+
+        "additional_build_steps": {
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "prepend": {
+                    "anyOf": [{"type": "string"}, {"type": "array"}],
+                },
+                "append": {
+                    "anyOf": [{"type": "string"}, {"type": "array"}],
+                },
+            },
+        },
+    },
+}
+
+
+def validate_schema(ee_def: dict):
+    schema_version = 1
+    if 'version' in ee_def:
+        try:
+            schema_version = int(ee_def['version'])
+        except ValueError:
+            raise DefinitionError(f"Schema version not an integer: {ee_def['version']}")
+
+    if schema_version not in (1, 2):
+        raise DefinitionError(f"Unsupported schema version: {schema_version}")
+
+    try:
+        if schema_version == 1:
+            validate(instance=ee_def, schema=schema_v1)
+        elif schema_version == 2:
+            validate(instance=ee_def, schema=schema_v2)
+    except (SchemaError, ValidationError) as e:
+        raise DefinitionError(msg=e.message, path=e.absolute_schema_path)

--- a/ansible_builder/exceptions.py
+++ b/ansible_builder/exceptions.py
@@ -1,10 +1,14 @@
 import sys
 
+from collections import deque
+from typing import Optional
+
 
 class DefinitionError(RuntimeError):
     # Eliminate the output of traceback before our custom error message prints out
     sys.tracebacklimit = 0
 
-    def __init__(self, msg):
+    def __init__(self, msg: str, path: Optional[deque] = None):
         super(DefinitionError, self).__init__("%s" % msg)
         self.msg = msg
+        self.path = path

--- a/ansible_builder/main.py
+++ b/ansible_builder/main.py
@@ -89,7 +89,7 @@ class AnsibleBuilder:
         resolved_keyring = None
 
         if policy is not None:
-            if self.version != "2":
+            if self.version != 2:
                 raise ValueError(f'--container-policy not valid with version {self.version} format')
 
             # Require podman runtime

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 PyYAML
 requirements-parser
 bindep
+jsonschema

--- a/test/unit/test_main.py
+++ b/test/unit/test_main.py
@@ -10,13 +10,13 @@ from ansible_builder.main import AnsibleBuilder
 def test_definition_version(exec_env_definition_file):
     path = exec_env_definition_file(content={'version': 1})
     aee = AnsibleBuilder(filename=path)
-    assert aee.version == '1'
+    assert aee.version == 1
 
 
 def test_definition_version_missing(exec_env_definition_file):
     path = exec_env_definition_file(content={})
     aee = AnsibleBuilder(filename=path)
-    assert aee.version == '1'
+    assert aee.version == 1
 
 
 @pytest.mark.parametrize('path_spec', ('absolute', 'relative'))
@@ -92,7 +92,7 @@ def test_build_command(exec_env_definition_file, runtime):
     content = {'version': 1}
     path = exec_env_definition_file(content=content)
 
-    aee = AnsibleBuilder(filename=path, tag='my-custom-image')
+    aee = AnsibleBuilder(filename=path, tag=['my-custom-image'])
     command = aee.build_command
     assert 'build' and 'my-custom-image' in command
 
@@ -100,7 +100,8 @@ def test_build_command(exec_env_definition_file, runtime):
 
     command = aee.build_command
     assert 'foo/bar/path' in command
-    assert 'foo/bar/path/Dockerfile' in " ".join(command)
+    fpath = 'foo/bar/path/' + constants.runtime_files[runtime]
+    assert fpath in " ".join(command)
 
 
 def test_nested_galaxy_file(data_dir, tmp_path):

--- a/test/unit/test_user_definition.py
+++ b/test/unit/test_user_definition.py
@@ -24,41 +24,39 @@ class TestUserDefinition:
         ),  # missing file
         (
             "{'version': 1, 'additional_build_steps': 'RUN me'}",
-            "Expected 'additional_build_steps' in the provided definition file to be a dictionary\n"
-            "with keys 'prepend' and/or 'append'; found a str instead."
+            "'RUN me' is not of type 'object'"
         ),  # not right format for additional_build_steps
         (
             "{'version': 1, 'additional_build_steps': {'middle': 'RUN me'}}",
-            "Keys ('middle',) are not allowed in 'additional_build_steps'."
+            "Additional properties are not allowed ('middle' was unexpected)"
         ),  # there are no "middle" build steps
         (
             "{'version': 1, 'build_arg_defaults': {'EE_BASE_IMAGE': ['foo']}}",
-            "Expected build_arg_defaults.EE_BASE_IMAGE to be a string; Found a <class 'list'> instead."
+            "['foo'] is not of type 'string'"
         ),  # image itself is wrong type
         (
             "{'version': 1, 'build_arg_defaults': {'BUILD_ARRRRRG': 'swashbuckler'}}",
-            "Keys {'BUILD_ARRRRRG'} are not allowed in 'build_arg_defaults'."
+            "Additional properties are not allowed ('BUILD_ARRRRRG' was unexpected)"
         ),  # image itself is wrong type
         (
             "{'version': 1, 'ansible_config': ['ansible.cfg']}",
-            "Expected 'ansible_config' in the provided definition file to\n"
-            "be a string; found a list instead."
+            "['ansible.cfg'] is not of type 'string'"
         ),
         (
             "{'version': 1, 'images': 'bar'}",
-            "Error: Unknown yaml key(s), {'images'}, found in the definition file."
+            "Additional properties are not allowed ('images' was unexpected)"
         ),
         (
             "{'version': 2, 'foo': 'bar'}",
-            "Error: Unknown yaml key(s), {'foo'}, found in the definition file."
+            "Additional properties are not allowed ('foo' was unexpected)"
         ),
         (
             "{'version': 2, 'build_arg_defaults': {'EE_BASE_IMAGE': 'foo'}, 'images': {}}",
-            "Error: Version 2 does not allow defining EE_BASE_IMAGE or EE_BUILDER_IMAGE in 'build_arg_defaults'"
+            "Additional properties are not allowed ('EE_BASE_IMAGE' was unexpected)"
         ),  # v1 base image defined in v2 file
         (
             "{'version': 2, 'build_arg_defaults': {'EE_BUILDER_IMAGE': 'foo'}, 'images': {}}",
-            "Error: Version 2 does not allow defining EE_BASE_IMAGE or EE_BUILDER_IMAGE in 'build_arg_defaults'"
+            "Additional properties are not allowed ('EE_BUILDER_IMAGE' was unexpected)"
         ),  # v1 builder image defined in v2 file
     ], ids=[
         'integer', 'missing_file', 'additional_steps_format', 'additional_unknown',
@@ -88,7 +86,7 @@ class TestUserDefinition:
         path = exec_env_definition_file("{'version': 1, 'bad_key': 1}")
         with pytest.raises(DefinitionError) as error:
             AnsibleBuilder(filename=path)
-        assert "Error: Unknown yaml key(s), {'bad_key'}, found in the definition file." in str(error.value.args[0])
+        assert "Additional properties are not allowed ('bad_key' was unexpected)" in str(error.value.args[0])
 
     def test_ee_missing_image_name(self, exec_env_definition_file):
         path = exec_env_definition_file("{'version': 2, 'images': { 'base_image': {'signature_original_name': ''}}}")


### PR DESCRIPTION
- Uses `jsonschema` to validate EE file during load.
- Custom EE schema validation error messages changed to use schema errors as supplied by `jsonschema`. Almost same level of detail.
- EE version specifier now treated as an `int` instead of `str`.