### PR TITLE
Fixes for integration tests

### DIFF
--- a/test/integration/test_build.py
+++ b/test/integration/test_build.py
@@ -30,7 +30,7 @@ def test_blank_execution_environment(cli, runtime, ee_tag, tmp_path, data_dir):
     bc = tmp_path
     ee_def = data_dir / 'blank' / 'execution-environment.yml'
     cli(
-        f'ansible-builder build -c {bc} -f {ee_def} -t {ee_tag} --container-runtime {runtime}'
+        f'ansible-builder build --no-cache -c {bc} -f {ee_def} -t {ee_tag} --container-runtime {runtime}'
     )
     result = cli(f'{runtime} run --rm {ee_tag} echo "This is a simple test"')
     assert 'This is a simple test' in result.stdout, result.stdout
@@ -42,7 +42,7 @@ def test_multiple_tags(cli, runtime, ee_tag, tmp_path, data_dir):
     bc = tmp_path
     ee_def = data_dir / 'blank' / 'execution-environment.yml'
     cli(
-        f'ansible-builder build -c {bc} -f {ee_def} -t {ee_tag} -t testmultitags --container-runtime {runtime}'
+        f'ansible-builder build --no-cache -c {bc} -f {ee_def} -t {ee_tag} -t testmultitags --container-runtime {runtime}'
     )
     result = cli(f'{runtime} run --rm {ee_tag} echo "test: test_multiple_tags 1"')
     assert 'test: test_multiple_tags 1' in result.stdout, result.stdout
@@ -56,7 +56,7 @@ def test_multiple_tags(cli, runtime, ee_tag, tmp_path, data_dir):
 def test_user_system_requirement(cli, runtime, ee_tag, tmp_path, data_dir):
     bc = tmp_path
     ee_def = data_dir / 'subversion' / 'execution-environment.yml'
-    command = f'ansible-builder build -c {bc} -f {ee_def} -t {ee_tag} --container-runtime {runtime}'
+    command = f'ansible-builder build --no-cache -c {bc} -f {ee_def} -t {ee_tag} --container-runtime {runtime}'
     cli(command)
     result = cli(
         f'{runtime} run --rm {ee_tag} svn --help'
@@ -69,7 +69,7 @@ def test_collection_system_requirement(cli, runtime, ee_tag, tmp_path, data_dir)
     bc = tmp_path
     ee_def = data_dir / 'ansible.posix.at' / 'execution-environment.yml'
     cli(
-        f'ansible-builder build -c {bc} -f {ee_def} -t {ee_tag} --container-runtime {runtime} -v3'
+        f'ansible-builder build --no-cache -c {bc} -f {ee_def} -t {ee_tag} --container-runtime {runtime} -v3'
     )
     result = cli(
         f'{runtime} run --rm {ee_tag} at -V'
@@ -81,7 +81,7 @@ def test_collection_system_requirement(cli, runtime, ee_tag, tmp_path, data_dir)
 def test_user_python_requirement(cli, runtime, ee_tag, tmp_path, data_dir):
     bc = tmp_path
     ee_def = data_dir / 'pip' / 'execution-environment.yml'
-    command = f'ansible-builder build -c {bc} -f {ee_def} -t {ee_tag} --container-runtime {runtime}'
+    command = f'ansible-builder build --no-cache -c {bc} -f {ee_def} -t {ee_tag} --container-runtime {runtime}'
     cli(command)
     result = cli(
         f'{runtime} run --rm {ee_tag} pip3 show awxkit'
@@ -98,7 +98,7 @@ def test_user_python_requirement(cli, runtime, ee_tag, tmp_path, data_dir):
 def test_python_git_requirement(cli, runtime, ee_tag, tmp_path, data_dir):
     bc = tmp_path
     ee_def = data_dir / 'needs_git' / 'execution-environment.yml'
-    command = f'ansible-builder build -c {bc} -f {ee_def} -t {ee_tag} --container-runtime {runtime}'
+    command = f'ansible-builder build --no-cache -c {bc} -f {ee_def} -t {ee_tag} --container-runtime {runtime}'
     cli(command)
     result = cli(f'{runtime} run --rm {ee_tag} pip3 freeze')
     assert 'flask' in result.stdout.lower(), result.stdout
@@ -112,7 +112,7 @@ def test_prepended_steps(cli, runtime, ee_tag, tmp_path, data_dir):
     bc = tmp_path
     ee_def = data_dir / 'prepend_steps' / 'execution-environment.yml'
     cli(
-        f'ansible-builder build -c {bc} -f {ee_def} -t {ee_tag} --container-runtime {runtime}'
+        f'ansible-builder build --no-cache -c {bc} -f {ee_def} -t {ee_tag} --container-runtime {runtime}'
     )
 
     _file = 'Dockerfile' if runtime == 'docker' else 'Containerfile'
@@ -128,7 +128,7 @@ def test_build_args_basic(cli, runtime, ee_tag, tmp_path, data_dir):
     bc = tmp_path
     ee_def = data_dir / 'build_args' / 'execution-environment.yml'
     result = cli(
-        f'ansible-builder build -c {bc} -f {ee_def} -t {ee_tag} --container-runtime {runtime} --build-arg FOO=bar -v3'
+        f'ansible-builder build --no-cache -c {bc} -f {ee_def} -t {ee_tag} --container-runtime {runtime} --build-arg FOO=bar -v3'
     )
     assert 'FOO=bar' in result.stdout
 
@@ -142,7 +142,7 @@ def test_build_args_from_environment(cli, runtime, ee_tag, tmp_path, data_dir):
     ee_def = data_dir / 'build_args' / 'execution-environment.yml'
     os.environ['FOO'] = 'secretsecret'
     result = cli(
-        f'ansible-builder build -c {bc} -f {ee_def} -t {ee_tag} --container-runtime {runtime} --build-arg FOO -v3'
+        f'ansible-builder build --no-cache -c {bc} -f {ee_def} -t {ee_tag} --container-runtime {runtime} --build-arg FOO -v3'
     )
     assert 'secretsecret' in result.stdout
 
@@ -154,10 +154,11 @@ def test_base_image_build_arg(cli, runtime, ee_tag, tmp_path, data_dir):
     os.environ['FOO'] = 'secretsecret'
 
     # Build with custom image tag, then use that as input to --build-arg EE_BASE_IMAGE
-    cli(f'ansible-builder build -c {bc} -f {ee_def} -t {ee_tag}-custom --container-runtime {runtime} -v3')
-    cli(f'ansible-builder build -c {bc} -f {ee_def} -t {ee_tag}-custom '
+    cli(f'ansible-builder build --no-cache -c {bc} -f {ee_def} -t {ee_tag}-custom --container-runtime {runtime} -v3')
+    cli(f'ansible-builder build --no-cache -c {bc} -f {ee_def} -t {ee_tag}-custom '
         f'--container-runtime {runtime} --build-arg EE_BASE_IMAGE={ee_tag}-custom -v3')
-    result = cli(f"{runtime} run {ee_tag}-custom cat /base_image")
+
+    result = cli(f"{runtime} run --rm {ee_tag}-custom cat /base_image")
     assert f"{ee_tag}-custom" in result.stdout
 
 
@@ -165,7 +166,7 @@ def test_base_image_build_arg(cli, runtime, ee_tag, tmp_path, data_dir):
 @pytest.mark.xfail(reason='Unreliable on podman')
 def test_has_pytz(cli, runtime, data_dir, ee_tag, tmp_path):
     ee_def = data_dir / 'pytz' / 'execution-environment.yml'
-    cli(f'ansible-builder build -c {tmp_path} -f {ee_def} -t {ee_tag} --container-runtime {runtime} -v 3')
+    cli(f'ansible-builder build --no-cache -c {tmp_path} -f {ee_def} -t {ee_tag} --container-runtime {runtime} -v 3')
     result = cli(f'{runtime} run --rm {ee_tag} pip3 show pytz')
 
     assert 'World timezone definitions, modern and historical' in result.stdout
@@ -197,7 +198,7 @@ def test_collection_verification_off(cli, runtime, data_dir, ee_tag, tmp_path):
     Test that, by default, collection verification is off via the env var.
     """
     ee_def = data_dir / 'ansible.posix.at' / 'execution-environment.yml'
-    result = cli(f'ansible-builder build -c {tmp_path} -f {ee_def} -t {ee_tag} --container-runtime {runtime} -v 3')
+    result = cli(f'ansible-builder build --no-cache -c {tmp_path} -f {ee_def} -t {ee_tag} --container-runtime {runtime} -v 3')
     assert "RUN ANSIBLE_GALAXY_DISABLE_GPG_VERIFY=1 ansible-galaxy" in result.stdout
 
 
@@ -211,7 +212,8 @@ def test_collection_verification_on(cli, runtime, data_dir, ee_tag, tmp_path):
     ee_def = data_dir / 'ansible.posix.at' / 'execution-environment.yml'
 
     # ansible-galaxy might error (older Ansible), but that should be ok
-    result = cli(f'ansible-builder build --galaxy-keyring {keyring} -c {tmp_path} -f {ee_def} -t {ee_tag} --container-runtime {runtime} -v 3', allow_error=True)
+    result = cli(f'ansible-builder build --no-cache --galaxy-keyring {keyring} -c {tmp_path} -f {ee_def} -t {ee_tag} --container-runtime {runtime} -v 3',
+                 allow_error=True)
 
     keyring_copy = tmp_path / constants.user_content_subfolder / constants.default_keyring_name
     assert keyring_copy.exists()
@@ -224,7 +226,7 @@ def test_collection_verification_on(cli, runtime, data_dir, ee_tag, tmp_path):
 @pytest.mark.test_all_runtimes
 def test_galaxy_signing_extra_args(cli, runtime, data_dir, ee_tag, tmp_path):
     """
-    Test that all extr asigning args for gpg are passed into the container file.
+    Test that all extra signing args for gpg are passed into the container file.
     """
     pytest.xfail("failing configuration (but should work)")
 
@@ -232,7 +234,7 @@ def test_galaxy_signing_extra_args(cli, runtime, data_dir, ee_tag, tmp_path):
     keyring.touch()
     ee_def = data_dir / 'ansible.posix.at' / 'execution-environment.yml'
 
-    result = cli(f'ansible-builder build -c {tmp_path} -f {ee_def} -t {ee_tag} --container-runtime {runtime} -v 3 '
+    result = cli(f'ansible-builder build --no-cache -c {tmp_path} -f {ee_def} -t {ee_tag} --container-runtime {runtime} -v 3 '
                  f'--galaxy-keyring {keyring} --galaxy-ignore-signature-status-code 500 '
                  f'--galaxy-required-valid-signature-count 3', allow_error=True)
 


### PR DESCRIPTION
- Adds a missing `--rm` option to a `run` container command within an integration test.
- Adds `--no-cache` to `ansible-builder build` commands in integration tests to fix random error from podman. Example errors:
   * `Error: error checking if cached image exists from a previous build: error getting top layer info: layer not known`
   * `Error: identifier is not a container: error building at STEP "COPY --from=builder /output/ /output/": error mounting build container "148f588cde5f3cc48ede5d8bb430d8abc7400c59b811e5ec57e00b46bb6a073e": layer not known`