### PR TITLE
[feature] allow custom commands before and after build phases

### DIFF
--- a/ansible_builder/containerfile.py
+++ b/ansible_builder/containerfile.py
@@ -143,12 +143,10 @@ class Containerfile:
             "",
         ])
 
-        self._insert_custom_steps('prepend')  # EE v1
-        self._insert_custom_steps('prepend_final')  # EE v2
+        self._insert_custom_steps('prepend_final')
         self._prepare_galaxy_copy_steps()
         self._prepare_system_runtime_deps_steps()
-        self._insert_custom_steps('append')  # EE v1
-        self._insert_custom_steps('append_final')  # EE v2
+        self._insert_custom_steps('append_final')
         self._prepare_label_steps()
 
     def write(self):

--- a/ansible_builder/ee_schema.py
+++ b/ansible_builder/ee_schema.py
@@ -200,3 +200,24 @@ def validate_schema(ee_def: dict):
             validate(instance=ee_def, schema=schema_v2)
     except (SchemaError, ValidationError) as e:
         raise DefinitionError(msg=e.message, path=e.absolute_schema_path)
+
+    _handle_aliasing(ee_def)
+
+
+def _handle_aliasing(ee_def: dict):
+    """
+    Upgrade EE keys into standard keys across schema versions.
+
+    Some EE keys are renamed across schema versions. So that we don't need to
+    check schema version, or do some other hackery, in the builder code when
+    accessing the values, just do the key name upgrades/aliasing here.
+    """
+
+    if 'additional_build_steps' in ee_def:
+        # V1 'prepend' == V2 'prepend_final'
+        if 'prepend' in ee_def['additional_build_steps']:
+            ee_def['additional_build_steps']['prepend_final'] = ee_def['additional_build_steps']['prepend']
+
+        # V1 'append' == V2 'append_final'
+        if 'append' in ee_def['additional_build_steps']:
+            ee_def['additional_build_steps']['append_final'] = ee_def['additional_build_steps']['append']

--- a/ansible_builder/ee_schema.py
+++ b/ansible_builder/ee_schema.py
@@ -46,6 +46,9 @@ schema_v1 = {
                 "ANSIBLE_GALAXY_CLI_COLLECTION_OPTS": {
                     "type": "string",
                 },
+                "ANSIBLE_GALAXY_CLI_ROLE_OPTS": {
+                    "type": "string",
+                },
             },
         },
 
@@ -105,6 +108,9 @@ schema_v2 = {
                 "ANSIBLE_GALAXY_CLI_COLLECTION_OPTS": {
                     "type": "string",
                 },
+                "ANSIBLE_GALAXY_CLI_ROLE_OPTS": {
+                    "type": "string",
+                },
             },
         },
 
@@ -123,6 +129,29 @@ schema_v2 = {
                 },
                 "system": {
                     "description": "The system dependency file",
+                    "type": "string",
+                },
+                "python_interpreter": {
+                    "description": "Python package name and path",
+                    "type": "object",
+                    "additionalProperties": False,
+                    "properties": {
+                        "package_name": {
+                            "description": "The python package to install",
+                            "type": "string",
+                        },
+                        "python_path": {
+                            "description": "Path to the python interpreter",
+                            "type": "string",
+                        },
+                    },
+                },
+                "ansible_core": {
+                    "description": "Ansible version for pip installation",
+                    "type": "string",
+                },
+                "ansible_runner": {
+                    "description": "Ansible Runner version for pip installation",
                     "type": "string",
                 },
             },

--- a/ansible_builder/ee_schema.py
+++ b/ansible_builder/ee_schema.py
@@ -152,10 +152,28 @@ schema_v2 = {
             "type": "object",
             "additionalProperties": False,
             "properties": {
-                "prepend": {
+                "prepend_base": {
                     "anyOf": [{"type": "string"}, {"type": "array"}],
                 },
-                "append": {
+                "append_base": {
+                    "anyOf": [{"type": "string"}, {"type": "array"}],
+                },
+                "prepend_galaxy": {
+                    "anyOf": [{"type": "string"}, {"type": "array"}],
+                },
+                "append_galaxy": {
+                    "anyOf": [{"type": "string"}, {"type": "array"}],
+                },
+                "prepend_builder": {
+                    "anyOf": [{"type": "string"}, {"type": "array"}],
+                },
+                "append_builder": {
+                    "anyOf": [{"type": "string"}, {"type": "array"}],
+                },
+                "prepend_final": {
+                    "anyOf": [{"type": "string"}, {"type": "array"}],
+                },
+                "append_final": {
                     "anyOf": [{"type": "string"}, {"type": "array"}],
                 },
             },

--- a/ansible_builder/ee_schema.py
+++ b/ansible_builder/ee_schema.py
@@ -3,6 +3,19 @@ from jsonschema import validate, SchemaError, ValidationError
 from ansible_builder.exceptions import DefinitionError
 
 
+TYPE_StringOrListOfStrings = {
+    "anyOf": [
+        {"type": "string"},
+        {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        }
+    ]
+}
+
+
 ############
 # Version 1
 ############
@@ -60,12 +73,8 @@ schema_v1 = {
             "type": "object",
             "additionalProperties": False,
             "properties": {
-                "prepend": {
-                    "anyOf": [{"type": "string"}, {"type": "array"}],
-                },
-                "append": {
-                    "anyOf": [{"type": "string"}, {"type": "array"}],
-                },
+                "prepend": TYPE_StringOrListOfStrings,
+                "append": TYPE_StringOrListOfStrings,
             },
         },
     },
@@ -152,30 +161,14 @@ schema_v2 = {
             "type": "object",
             "additionalProperties": False,
             "properties": {
-                "prepend_base": {
-                    "anyOf": [{"type": "string"}, {"type": "array"}],
-                },
-                "append_base": {
-                    "anyOf": [{"type": "string"}, {"type": "array"}],
-                },
-                "prepend_galaxy": {
-                    "anyOf": [{"type": "string"}, {"type": "array"}],
-                },
-                "append_galaxy": {
-                    "anyOf": [{"type": "string"}, {"type": "array"}],
-                },
-                "prepend_builder": {
-                    "anyOf": [{"type": "string"}, {"type": "array"}],
-                },
-                "append_builder": {
-                    "anyOf": [{"type": "string"}, {"type": "array"}],
-                },
-                "prepend_final": {
-                    "anyOf": [{"type": "string"}, {"type": "array"}],
-                },
-                "append_final": {
-                    "anyOf": [{"type": "string"}, {"type": "array"}],
-                },
+                "prepend_base": TYPE_StringOrListOfStrings,
+                "append_base": TYPE_StringOrListOfStrings,
+                "prepend_galaxy": TYPE_StringOrListOfStrings,
+                "append_galaxy": TYPE_StringOrListOfStrings,
+                "prepend_builder": TYPE_StringOrListOfStrings,
+                "append_builder": TYPE_StringOrListOfStrings,
+                "prepend_final": TYPE_StringOrListOfStrings,
+                "append_final": TYPE_StringOrListOfStrings,
             },
         },
     },

--- a/ansible_builder/user_definition.py
+++ b/ansible_builder/user_definition.py
@@ -214,3 +214,7 @@ class UserDefinition:
 
                 # Must set these values so that Containerfile uses the proper images
                 self.build_arg_defaults['EE_BASE_IMAGE'] = self.base_image.name
+                if self.builder_image:
+                    self.build_arg_defaults['EE_BUILDER_IMAGE'] = self.builder_image.name
+                else:
+                    self.build_arg_defaults['EE_BUILDER_IMAGE'] = None

--- a/docs/definition.rst
+++ b/docs/definition.rst
@@ -149,6 +149,9 @@ the following changes:
    base and builder images.
 2. Defining ``EE_BASE_IMAGE`` or ``EE_BUILDER_IMAGE`` in the ``build_args_defaults``
    section, or with the :ref:`build-arg` CLI option, is no longer allowed.
+3. The ``additional_build_steps`` section allows for specifying additional commands
+   either before or after each of the four build phases (base/galaxy/builder/final).
+   The version 1 format supported this for only the final build phase.
 
 An example version 2 execution environment definition schema is as follows:
 
@@ -173,6 +176,14 @@ An example version 2 execution environment definition schema is as follows:
       builder_image:
         name: my-mirror.example.com/aap-mirror/ansible-builder-rhel8:latest
         signature_original_name: registry.redhat.io/ansible-automation-platform-21/ansible-builder-rhel8:latest
+
+    additional_build_steps:
+      prepend_final: |
+        RUN whoami
+        RUN cat /etc/os-release
+      append_final:
+        - RUN echo This is a post-install command!
+        - RUN ls -la /etc
 
 images
 ^^^^^^
@@ -211,3 +222,38 @@ Valid keys for this section are:
   key must be supplied with the container image to use. Use the ``signature_original_name``
   key if the image is mirrored within your repository, but signed with the original
   image's signature key. Image names *MUST* contain a tag, such as ``:latest``.
+
+additional_build_steps (v2)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Similar to the version 1 format, you can specify custom build commands in this
+section, but for all build phases.
+
+Below are the valid keys for this section. Each supports either a multi-line
+string, or a list of strings.
+
+``prepend_base``
+  Commands to insert before building of the base image.
+
+``append_base``
+  Commands to insert after building of the base image.
+
+``prepend_galaxy``
+  Commands to insert before building of the galaxy image.
+
+``append_galaxy``
+  Commands to insert after building of the galaxy image.
+
+``prepend_builder``
+  Commands to insert before building of the builder image.
+
+``append_builder``
+  Commands to insert after building of the builder image.
+
+``prepend_final``
+  Commands to insert before building of the final image. This is the equivalent
+  of the ``prepend`` version 1 keyword.
+
+``append_final``
+  Commands to insert after building of the final image. This is the equivalent
+  of the ``append`` version 1 keyword.

--- a/test/data/v2/complete/ee.yml
+++ b/test/data/v2/complete/ee.yml
@@ -1,0 +1,19 @@
+---
+version: 2
+
+images:
+  base_image:
+    name: registry.redhat.io/ansible-automation-platform-21/ee-minimal-rhel8:latest
+  builder_image:
+    name: my-mirror.example.com/aap-mirror/ansible-builder-rhel8:latest
+
+build_arg_defaults:
+  ANSIBLE_GALAXY_CLI_COLLECTION_OPTS: '--foo'
+  ANSIBLE_GALAXY_CLI_ROLE_OPTS: '--bar'
+
+dependencies:
+  ansible_core: ansible-core==2.13
+  ansible_runner: ansible-runner==2.3.1
+  python_interpreter:
+    package_name: "mypython3"
+    python_path: "/usr/local/bin/mypython"

--- a/test/data/v2/pre_and_post/ee.yml
+++ b/test/data/v2/pre_and_post/ee.yml
@@ -2,10 +2,12 @@
 version: 2
 
 additional_build_steps:
-  prepend_base:
-    - ARG PRE_BASE
+  prepend_base: |
+    ARG PRE_BASE1
+    ARG PRE_BASE2
   append_base:
-    - ARG POST_BASE
+    - ARG POST_BASE1
+    - ARG POST_BASE2
   prepend_galaxy:
     - ARG PRE_GALAXY
   append_galaxy:

--- a/test/data/v2/pre_and_post/ee.yml
+++ b/test/data/v2/pre_and_post/ee.yml
@@ -1,0 +1,20 @@
+---
+version: 2
+
+additional_build_steps:
+  prepend_base:
+    - ARG PRE_BASE
+  append_base:
+    - ARG POST_BASE
+  prepend_galaxy:
+    - ARG PRE_GALAXY
+  append_galaxy:
+    - ARG POST_GALAXY
+  prepend_builder:
+    - ARG PRE_BUILDER
+  append_builder:
+    - ARG POST_BUILDER
+  prepend_final:
+    - ARG PRE_FINAL
+  append_final:
+    - ARG POST_FINAL

--- a/test/integration/test_create.py
+++ b/test/integration/test_create.py
@@ -108,7 +108,7 @@ def test_collection_verification_on(cli, build_dir_and_ee_yml):
 
 def test_galaxy_signing_extra_args(cli, build_dir_and_ee_yml):
     """
-    Test that all extr asigning args for gpg are passed into the container file.
+    Test that all extra signing args for gpg are passed into the container file.
     """
     ee = [
         'dependencies:',
@@ -154,3 +154,22 @@ def test_pre_post_commands(cli, data_dir, tmp_path):
     assert "ARG POST_BUILDER" in text
     assert "ARG PRE_FINAL" in text
     assert "ARG POST_FINAL" in text
+
+
+def test_v2_complete(cli, data_dir, tmp_path):
+    """For testing various elements in a complete v2 EE file"""
+    ee_def = data_dir / 'v2' / 'complete' / 'ee.yml'
+    r = cli(f'ansible-builder create -c {str(tmp_path)} -f {ee_def}')
+    assert r.rc == 0
+
+    containerfile = tmp_path / "Containerfile"
+    assert containerfile.exists()
+    text = containerfile.read_text()
+
+    assert 'ARG EE_BASE_IMAGE="registry.redhat.io/ansible-automation-platform-21/ee-minimal-rhel8:latest"\n' in text
+    assert 'ARG EE_BUILDER_IMAGE="my-mirror.example.com/aap-mirror/ansible-builder-rhel8:latest"\n' in text
+    assert 'ARG PYCMD="/usr/local/bin/mypython"\n' in text
+    assert 'ARG PYPKG="mypython3"\n' in text
+    assert 'ARG ANSIBLE_GALAXY_CLI_COLLECTION_OPTS="--foo"\n' in text
+    assert 'ARG ANSIBLE_GALAXY_CLI_ROLE_OPTS="--bar"\n' in text
+    assert 'ARG ANSIBLE_INSTALL_REFS="ansible-core==2.13 ansible-runner==2.3.1"\n' in text

--- a/test/integration/test_create.py
+++ b/test/integration/test_create.py
@@ -132,3 +132,23 @@ def test_galaxy_signing_extra_args(cli, build_dir_and_ee_yml):
 
     assert "--ignore-signature-status-code 500" in text
     assert "--required-valid-signature-count 3" in text
+
+
+def test_pre_post_commands(cli, data_dir, tmp_path):
+    """Test that the pre/post commands are inserted"""
+    ee_def = data_dir / 'v2' / 'pre_and_post' / 'ee.yml'
+    r = cli(f'ansible-builder create -c {str(tmp_path)} -f {ee_def}')
+    assert r.rc == 0
+
+    containerfile = tmp_path / "Containerfile"
+    assert containerfile.exists()
+    text = containerfile.read_text()
+
+    assert "ARG PRE_BASE" in text
+    assert "ARG POST_BASE" in text
+    assert "ARG PRE_GALAXY" in text
+    assert "ARG POST_GALAXY" in text
+    assert "ARG PRE_BUILDER" in text
+    assert "ARG POST_BUILDER" in text
+    assert "ARG PRE_FINAL" in text
+    assert "ARG POST_FINAL" in text

--- a/test/integration/test_create.py
+++ b/test/integration/test_create.py
@@ -144,8 +144,10 @@ def test_pre_post_commands(cli, data_dir, tmp_path):
     assert containerfile.exists()
     text = containerfile.read_text()
 
-    assert "ARG PRE_BASE" in text
-    assert "ARG POST_BASE" in text
+    assert "ARG PRE_BASE1\n" in text
+    assert "ARG PRE_BASE2\n" in text
+    assert "ARG POST_BASE1\n" in text
+    assert "ARG POST_BASE2\n" in text
     assert "ARG PRE_GALAXY" in text
     assert "ARG POST_GALAXY" in text
     assert "ARG PRE_BUILDER" in text

--- a/test/unit/test_main.py
+++ b/test/unit/test_main.py
@@ -84,7 +84,7 @@ def test_base_image_via_definition_file_build_arg(exec_env_definition_file, tmp_
     with open(aee.containerfile.path) as f:
         content = f.read()
 
-    assert 'EE_BASE_IMAGE=my-other-custom-image' in content
+    assert 'EE_BASE_IMAGE="my-other-custom-image"' in content
 
 
 @pytest.mark.test_all_runtimes

--- a/test/unit/test_user_definition.py
+++ b/test/unit/test_user_definition.py
@@ -98,6 +98,21 @@ class TestUserDefinition:
             AnsibleBuilder(filename=path)
         assert "'name' is a required field for 'base_image'" in str(error.value.args[0])
 
+    def test_v1_to_v2_key_upgrades(self, exec_env_definition_file):
+        """ Test that EE schema keys are upgraded from version V1 to V2. """
+        path = exec_env_definition_file("{'version': 1, 'additional_build_steps': {'prepend': 'value1', 'append': 'value2'}}")
+        definition = UserDefinition(path)
+        definition.validate()
+        add_bld_steps = definition.raw['additional_build_steps']
+        assert 'prepend' in add_bld_steps
+        assert 'append' in add_bld_steps
+        assert add_bld_steps['prepend'] == 'value1'
+        assert add_bld_steps['append'] == 'value2'
+        assert 'prepend_final' in add_bld_steps
+        assert 'append_final' in add_bld_steps
+        assert add_bld_steps['prepend_final'] == add_bld_steps['prepend']
+        assert add_bld_steps['append_final'] == add_bld_steps['append']
+
 
 class TestImageDescription:
 

--- a/test/unit/test_user_definition.py
+++ b/test/unit/test_user_definition.py
@@ -58,10 +58,14 @@ class TestUserDefinition:
             "{'version': 2, 'build_arg_defaults': {'EE_BUILDER_IMAGE': 'foo'}, 'images': {}}",
             "Additional properties are not allowed ('EE_BUILDER_IMAGE' was unexpected)"
         ),  # v1 builder image defined in v2 file
+        (
+            "{'version': 2, 'additional_build_steps': {'prepend': ''}}",
+            "Additional properties are not allowed ('prepend' was unexpected)"
+        ),  # 'prepend' is renamed in v2
     ], ids=[
         'integer', 'missing_file', 'additional_steps_format', 'additional_unknown',
         'build_args_value_type', 'unexpected_build_arg', 'config_type', 'v1_contains_v2_key',
-        'v2_unknown_key', 'v1_base_image_in_v2', 'v1_builder_image_in_v2'
+        'v2_unknown_key', 'v1_base_image_in_v2', 'v1_builder_image_in_v2', 'prepend_in_v2',
     ])
     def test_yaml_error(self, exec_env_definition_file, yaml_text, expect):
         path = exec_env_definition_file(yaml_text)

--- a/test/unit/test_user_definition.py
+++ b/test/unit/test_user_definition.py
@@ -113,6 +113,32 @@ class TestUserDefinition:
         assert add_bld_steps['prepend_final'] == add_bld_steps['prepend']
         assert add_bld_steps['append_final'] == add_bld_steps['append']
 
+    def test_v2_images(self, exec_env_definition_file):
+        """
+        Verify that image definition contents are assigned correctly and copied
+        to the build_arg_defaults equivalents.
+        """
+        path = exec_env_definition_file(
+            "{'version': 2, 'images': { 'base_image': {'name': 'base_image:latest'}, 'builder_image': {'name': 'builder_image:latest'} }}"
+        )
+        definition = UserDefinition(path)
+        definition.validate()
+
+        assert definition.base_image.name == "base_image:latest"
+        assert definition.builder_image.name == "builder_image:latest"
+        assert definition.build_arg_defaults['EE_BASE_IMAGE'] == "base_image:latest"
+        assert definition.build_arg_defaults['EE_BUILDER_IMAGE'] == "builder_image:latest"
+
+    def test_v2_ansible_install_refs(self, exec_env_definition_file):
+        path = exec_env_definition_file(
+            "{'version': 2, 'dependencies': {'ansible_core': 'ansible-core==2.13', 'ansible_runner': 'ansible-runner==2.3.1'}}"
+        )
+        definition = UserDefinition(path)
+        definition.validate()
+        assert definition.ansible_core_ref == "ansible-core==2.13"
+        assert definition.ansible_runner_ref == "ansible-runner==2.3.1"
+        assert definition.ansible_ref_install_list == "ansible-core==2.13 ansible-runner==2.3.1"
+
 
 class TestImageDescription:
 


### PR DESCRIPTION
Adds a new feature to allow custom Containerfile steps to be inserted before and after each of the four build phases (base, galaxy, builder, and final). These custom steps can be specified within the `additional_build_steps` section of the execution environment file.

The v1 `prepend` and `append` build step keywords are renamed to `prepend_final` and `append_final`, respectively. The new EE schema validation will make sure the keywords are correct for the EE schema version.

Also fixes the following bugs (with tests to validate):
- EE schema validation was missing some valid keys (`ANSIBLE_GALAXY_CLI_ROLE_OPTS`, `python_interpreter`, `ansible_core`, `ansible_runner`)
- `ARG` values should be quoted in case a value includes spaces (e.g., `ANSIBLE_INSTALL_REFS`)
- `self.build_arg_defaults['EE_BUILDER_IMAGE']` was not being set so its value was not being used