### PR TITLE
Enforce min python version and lint fixes

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -14,6 +14,9 @@ rules:
     level: error
   line-length: disable
   document-start: disable
+  indentation:
+    spaces: consistent
+    indent-sequences: consistent
   truthy:
     allowed-values:
       - 'True'

--- a/Containerfile
+++ b/Containerfile
@@ -1,20 +1,19 @@
-ARG PYTHON_BASE_IMAGE=quay.io/ansible/python-base:latest
-ARG PYTHON_BUILDER_IMAGE=quay.io/ansible/python-builder:latest
+ARG BASE_IMAGE=quay.io/centos/centos:stream9
 
-FROM $PYTHON_BUILDER_IMAGE as builder
-# =============================================================================
-ARG ZUUL_SIBLINGS
-
+FROM $BASE_IMAGE as builder
 # build this library (meaning ansible-builder)
 COPY . /tmp/src
-RUN assemble
-FROM $PYTHON_BASE_IMAGE
-# =============================================================================
+COPY ./ansible_builder/_target_scripts/* /output/scripts/
+RUN python3 -m ensurepip
+RUN python3 -m pip install --upgrade pip
+RUN python3 -m pip install --no-cache-dir bindep wheel
+RUN /output/scripts/assemble
 
+FROM $BASE_IMAGE
 COPY --from=builder /output/ /output
 # building EEs require the install-from-bindep script, but not the rest of the /output folder
-RUN /output/install-from-bindep && find /output/* -not -name install-from-bindep -exec rm -rf {} +
+RUN /output/scripts/install-from-bindep && find /output/* -not -name install-from-bindep -exec rm -rf {} +
 
-# move the assemble scripts themselves into this container
-COPY --from=builder /usr/local/bin/assemble /usr/local/bin/assemble
-COPY --from=builder /usr/local/bin/get-extras-packages /usr/local/bin/get-extras-packages
+# copy the assemble scripts themselves into this container
+COPY ./ansible_builder/_target_scripts/assemble /usr/local/bin/assemble
+COPY ./ansible_builder/_target_scripts/get-extras-packages /usr/local/bin/get-extras-packages

--- a/setup.py
+++ b/setup.py
@@ -5,4 +5,5 @@ from setuptools import setup
 setup(
     setup_requires=['pbr'],
     pbr=True,
+    python_requires=">=3.9",
 )


### PR DESCRIPTION
- Fix `yamllint` errors due to new release.
- Actually enforce a minimum python3 version during installation.
- Updates the `Containerfile` to use a more recent base image, `centos:stream9`, which contains a version of python3 that meets the minimum requirement.