### PR TITLE
Add mypy to linters job and correct existing errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   sanity:
     name: ${{ matrix.test.name }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
       image: quay.io/ansible/ansible-builder-test-container:2.0.0
       env:
@@ -20,7 +20,7 @@ jobs:
       matrix:
         test:
           - name: Lint
-            tox_env: linters
+            tox_env: linters-py39
 
           - name: Docs
             tox_env: docs
@@ -36,7 +36,7 @@ jobs:
         run: tox
 
   secrets_preflight:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Secrets pre-flight check
     env:
       secret_user: ${{ secrets.RH_REGISTRY_USER }}
@@ -51,7 +51,7 @@ jobs:
 
 
   pulp_integration:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Pulp Integration - ${{ matrix.py_version.name }}
     # NB: running this job requires access to an RH registry token; PRs can't currently access the main repo secret,
     # so forks will need to define the secrets locally to run these tests pre-merge
@@ -103,7 +103,7 @@ jobs:
 
 
   integration:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Integration - ${{ matrix.py_version.name }}
 
     env:
@@ -153,7 +153,7 @@ jobs:
 
   unit:
     name: Unit - ${{ matrix.py_version.name}}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container:
       image: quay.io/ansible/ansible-builder-test-container:2.0.0
       env:

--- a/ansible_builder/exceptions.py
+++ b/ansible_builder/exceptions.py
@@ -1,14 +1,15 @@
+from __future__ import annotations
+
 import sys
 
-from collections import deque
-from typing import Optional
+from typing import Sequence
 
 
 class DefinitionError(RuntimeError):
     # Eliminate the output of traceback before our custom error message prints out
     sys.tracebacklimit = 0
 
-    def __init__(self, msg: str, path: Optional[deque] = None):
+    def __init__(self, msg: str, path: Sequence[str | int] | None = None):
         super(DefinitionError, self).__init__("%s" % msg)
         self.msg = msg
         self.path = path

--- a/ansible_builder/user_definition.py
+++ b/ansible_builder/user_definition.py
@@ -4,6 +4,7 @@ import tempfile
 import yaml
 
 from pathlib import Path
+from typing import Callable
 
 from . import constants
 from .exceptions import DefinitionError
@@ -24,7 +25,7 @@ ALLOWED_KEYS_V2 = [
 
 
 # HACK: manage lifetimes more carefully
-_tempfiles: list[type[tempfile.TemporaryFile]] = []
+_tempfiles: list[Callable] = []
 
 
 class ImageDescription:

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,8 +1,11 @@
 coverage
 flake8
+mypy==1.0.1
 pytest
 pytest-cov
 pytest-mock
 pytest-xdist
+types-jsonschema
+types-pyyaml
 tox
 yamllint

--- a/tox.ini
+++ b/tox.ini
@@ -9,13 +9,14 @@ deps =
     -r {toxinidir}/test/requirements.txt
 commands = pytest {posargs}
 
-[testenv:linters]
+[testenv:linters{,-py39,-py310}]
 description = Run code linters
 commands =
     flake8 --version
     flake8 ansible_builder test
     yamllint --version
     yamllint -s .
+    mypy ansible_builder
 
 [testenv:unit{,-py39,-py310}]
 description = Run unit tests


### PR DESCRIPTION
Adds mypy call to existing `linters` job.

- Forces linting with Python 3.9 (the min supported version) and pins mypy at current version.
- We go ahead and update the GH hosted runner to the latest Ubuntu version.