### PR TITLE
Add check for Ansible/Runner in final image

### DIFF
--- a/ansible_builder/_target_scripts/check_ansible
+++ b/ansible_builder/_target_scripts/check_ansible
@@ -1,0 +1,110 @@
+#!/bin/bash
+# Copyright (c) 2023 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#####################################################################
+# Script to validate that Ansible and Ansible Runner are installed.
+#
+# Usage: check_ansible <PYCMD>
+#
+# Options:
+#     PYCMD - The path to the python executable to use.
+#####################################################################
+
+set -x
+
+PYCMD=$1
+
+if [ -z "$PYCMD" ]
+then
+    echo "Usage: check_ansible <PYCMD>"
+    exit 1
+fi
+
+if [ ! -x "$PYCMD" ]
+then
+    echo "$PYCMD is not an executable"
+    exit 1
+fi
+
+ansible --version
+
+if [ $? -ne 0 ]
+then
+    cat<<EOF
+**********************************************************************
+ERROR - Missing Ansible installation
+
+  An Ansible installation cannot be found in the final builder image.
+
+  Ansible must be installed in the final image. If you are using a
+  recent enough version of the execution environment file, you may
+  use the 'dependencies.ansible_core' configuration option to install
+  Ansible for you, or use 'additional_build_steps' to manually do
+  this yourself. Alternatively, use a base image with Ansible already
+  installed.
+**********************************************************************
+EOF
+    exit 1
+fi
+
+ansible-runner --version
+
+if [ $? -ne 0 ]
+then
+    cat<<EOF
+**********************************************************************
+ERROR - Missing Ansible Runner installation
+
+  An Ansible Runner installation cannot be found in the final builder
+  image.
+
+  Ansible Runner must be installed in the final image. If you are
+  using a recent enough version of the execution environment file, you
+  may use the 'dependencies.ansible_runner' configuration option to
+  install Ansible Runner for you, or use 'additional_build_steps' to
+  manually do this yourself. Alternatively, use a base image with
+  Ansible Runner already installed.
+**********************************************************************
+EOF
+    exit 1
+fi
+
+$PYCMD -c 'import ansible ; import ansible_runner'
+
+if [ $? -ne 0 ]
+then
+    cat<<EOF
+**********************************************************************
+ERROR - Missing Ansible or Ansible Runner for selected Python
+
+  An Ansible and/or Ansible Runner installation cannot be found in
+  the final builder image using the following Python interpreter:
+
+    $PYCMD
+
+  Ansible and Ansible Runner must be installed in the final image and
+  available to the selected Python interpreter. If you are using a
+  recent enough version of the execution environment file, you may use
+  the 'dependencies.ansible_core' configuration option to install
+  Ansible and the 'dependencies.ansible_runner' configuration option
+  to install Ansible Runner. You can also use 'additional_build_steps'
+  to manually do this yourself. Alternatively, use a base image with
+  Ansible and Ansible Runner already installed.
+**********************************************************************
+EOF
+    exit 1
+fi
+exit 0

--- a/ansible_builder/containerfile.py
+++ b/ansible_builder/containerfile.py
@@ -148,6 +148,12 @@ class Containerfile:
 
         self._insert_global_args()
         self._insert_custom_steps('prepend_final')
+
+        # Run the check for 'ansible' and 'ansible-runner' installations for
+        # any EE version 3 or above, unless explicitly skipped.
+        if self.definition.version >= 3 and not self.definition.options['skip_ansible_check']:
+            self.steps.append("RUN /output/scripts/check_ansible $PYCMD")
+
         self._prepare_galaxy_copy_steps()
         self._prepare_system_runtime_deps_steps()
         self._insert_custom_steps('append_final')
@@ -223,7 +229,7 @@ class Containerfile:
 
         # HACK: this sucks
         scriptres = importlib.resources.files('ansible_builder._target_scripts')
-        for script in ('assemble', 'get-extras-packages', 'install-from-bindep', 'introspect.py', 'check_galaxy'):
+        for script in ('assemble', 'get-extras-packages', 'install-from-bindep', 'introspect.py', 'check_galaxy', 'check_ansible'):
             with importlib.resources.as_file(scriptres / script) as script_path:
                 # FIXME: just use builtin copy?
                 copy_file(str(script_path), scripts_dir)

--- a/ansible_builder/ee_schema.py
+++ b/ansible_builder/ee_schema.py
@@ -290,6 +290,18 @@ schema_v3 = {
                 "required": ["src", "dest"],
             },
         },
+
+        "options": {
+            "description": "Options that effect runtime behavior",
+            "type": "object",
+            "additionalProperties": False,
+            "properties": {
+                "skip_ansible_check": {
+                    "description": "Disables the check for Ansible/Runner in final image",
+                    "type": "boolean",
+                },
+            },
+        },
     },
 }
 
@@ -316,6 +328,7 @@ def validate_schema(ee_def: dict):
         raise DefinitionError(msg=e.message, path=e.absolute_schema_path)
 
     _handle_aliasing(ee_def)
+    _handle_options_defaults(ee_def)
 
 
 def _handle_aliasing(ee_def: dict):
@@ -335,3 +348,16 @@ def _handle_aliasing(ee_def: dict):
         # V1/V2 'append' == V3 'append_final'
         if 'append' in ee_def['additional_build_steps']:
             ee_def['additional_build_steps']['append_final'] = ee_def['additional_build_steps']['append']
+
+
+def _handle_options_defaults(ee_def: dict):
+    """
+    JSONSchema can document a "default" value, but it isn't used for validation.
+    This method is used to set any default values for the "options" dictionary
+    properties.
+    """
+    if 'options' not in ee_def:
+        ee_def['options'] = {}
+
+    if ee_def['options'].get('skip_ansible_check') is None:
+        ee_def['options']['skip_ansible_check'] = False

--- a/ansible_builder/user_definition.py
+++ b/ansible_builder/user_definition.py
@@ -151,6 +151,11 @@ class UserDefinition:
     def additional_build_files(self):
         return self.raw.get('additional_build_files', [])
 
+    @property
+    def options(self):
+        # Since some options have default values, the 'options' key is always available
+        return self.raw['options']
+
     def get_dep_abs_path(self, entry):
         """Unique to the user EE definition, files can be referenced by either
         an absolute path or a path relative to the EE definition folder

--- a/docs/definition.rst
+++ b/docs/definition.rst
@@ -261,6 +261,24 @@ Valid keys for this section are:
       key if the image is mirrored within your repository, but signed with the original
       image's signature key. Image names *MUST* contain a tag, such as ``:latest``.
 
+options
+*******
+
+This section is a dictionary that contains keywords/options that can affect
+builder runtime functionality. Valid keys for this section are:
+
+    ``skip_ansible_check``
+      This boolean value controls whether or not the check for an installation
+      of Ansible and Ansible Runner is performed on the final image. Set this
+      value to ``True`` to not perform this check. The default is ``False``.
+
+Example ``options`` section:
+
+.. code:: yaml
+
+    options:
+        skip_ansible_check: True
+
 version
 *******
 

--- a/test/integration/test_create.py
+++ b/test/integration/test_create.py
@@ -239,6 +239,9 @@ def test_v3_complete(cli, data_dir, tmp_path):
     # verify that the ansible-galaxy command check is performed
     assert 'RUN /output/scripts/check_galaxy' in text
 
+    # verify that the ansible/runner check is performed
+    assert 'RUN /output/scripts/check_ansible' in text
+
     # check additional_build_files
     myconfigs_path = tmp_path / constants.user_content_subfolder / "myconfigs"
     assert myconfigs_path.is_dir()
@@ -259,3 +262,23 @@ def test_v3_complete(cli, data_dir, tmp_path):
     assert text_files.is_dir()
     a_text = text_files / "a.txt"
     assert a_text.exists()
+
+
+def test_v3_skip_ansible_check(cli, build_dir_and_ee_yml):
+    """
+    Test 'options.skip_ansible_check' works.
+    """
+    ee = [
+        'version: 3',
+        'options:',
+        '  skip_ansible_check: True',
+    ]
+
+    tmpdir, eeyml = build_dir_and_ee_yml("\n".join(ee))
+    cli(f'ansible-builder create -c {tmpdir} -f {eeyml} --output-filename Containerfile')
+
+    containerfile = tmpdir / "Containerfile"
+    assert containerfile.exists()
+    text = containerfile.read_text()
+
+    assert "check_ansible" not in text

--- a/test/unit/test_user_definition.py
+++ b/test/unit/test_user_definition.py
@@ -86,12 +86,16 @@ class TestUserDefinition:
             "{'version': 3, 'images': { 'base_image': {'name': 'base_image:latest'}, 'builder_image': {'name': 'builder_image:latest'} }}",
             "Additional properties are not allowed ('builder_image' was unexpected)"
         ),  # builder_image not suppored in v3
+        (
+            "{'version': 3, 'options': { 'skip_ansible_check': 'True' } }",
+            "'True' is not of type 'boolean'"
+        ),
     ], ids=[
         'integer', 'missing_file', 'additional_steps_format', 'additional_unknown',
         'build_args_value_type', 'unexpected_build_arg', 'config_type', 'v1_contains_v2_key',
         'v2_unknown_key', 'v1_base_image_in_v2', 'v1_builder_image_in_v2', 'prepend_in_v3',
         'dest_has_dot_dot', 'dest_is_absolute', 'src_req', 'dest_req', 'ansible_cfg',
-        'builder_in_v3'
+        'builder_in_v3', 'opt_skip_ans_chk',
     ])
     def test_yaml_error(self, exec_env_definition_file, yaml_text, expect):
         path = exec_env_definition_file(yaml_text)
@@ -190,6 +194,19 @@ class TestUserDefinition:
 
         system_req = definition.raw.get('dependencies', {}).get('system')
         assert system_req == ['req1', 'req2']
+
+    def test_v3_skip_ansible_check_default(self, exec_env_definition_file):
+        """
+        Test that options.skip_ansible_check defaults to False
+        """
+        path = exec_env_definition_file(
+            "{'version': 3}"
+        )
+        definition = UserDefinition(path)
+        definition.validate()
+
+        value = definition.raw.get('options', {}).get('skip_ansible_check')
+        assert value is False
 
 
 class TestImageDescription:


### PR DESCRIPTION
- New script added to run a check for Ansible and Runner installations.
- New 'options' EE keyword introduced to control builder runtime decisions. First option is for skipping the new Ansible/Runner check.