### PR TITLE
Add option for package manager

### DIFF
--- a/.github/test-scripts/setup_pulp.sh
+++ b/.github/test-scripts/setup_pulp.sh
@@ -111,7 +111,7 @@ export XDG_RUNTIME_DIR=/tmp/pulptests
 mkdir $XDG_RUNTIME_DIR
 
 skopeo login --username admin --password password localhost:8080 --tls-verify=false
-skopeo copy docker://registry.access.redhat.com/ubi9/ubi-micro:latest docker://localhost:8080/testrepo/ubi-micro --dest-tls-verify=false
+skopeo copy docker://registry.access.redhat.com/ubi9/ubi-minimal:latest docker://localhost:8080/testrepo/ubi-minimal --dest-tls-verify=false
 
 podman login --username "$1" --password "$2" registry.redhat.io
 skopeo copy docker://registry.redhat.io/ansible-automation-platform-21/ansible-builder-rhel8:latest docker://localhost:8080/testrepo/ansible-builder-rhel8 --dest-tls-verify=false

--- a/ansible_builder/_target_scripts/assemble
+++ b/ansible_builder/_target_scripts/assemble
@@ -37,12 +37,16 @@ if [ -z $PKGMGR ]; then
     PKGMGR=/usr/bin/dnf
     if [ -f "/usr/bin/microdnf" ]; then
         PKGMGR=/usr/bin/microdnf
-        if [ -z $PKGMGR_OPTS ]; then
-            # NOTE(pabelanger): skip install docs and weak dependencies to
-            # make smaller images. Sadly, setting these in dnf.conf don't
-            # appear to work.
-            PKGMGR_OPTS="--nodocs --setopt install_weak_deps=0"
-        fi
+    fi
+fi
+
+if [ "$PKGMGR" = "/usr/bin/microdnf" ]
+then
+    if [ -z $PKGMGR_OPTS ]; then
+        # NOTE(pabelanger): skip install docs and weak dependencies to
+        # make smaller images. Sadly, setting these in dnf.conf don't
+        # appear to work.
+        PKGMGR_OPTS="--nodocs --setopt install_weak_deps=0"
     fi
 fi
 

--- a/ansible_builder/_target_scripts/assemble
+++ b/ansible_builder/_target_scripts/assemble
@@ -58,7 +58,7 @@ mkdir -p /tmp/src
 
 cd /tmp/src
 
-$PKGMGR update -y
+$PKGMGR upgrade -y
 
 function install_bindep {
     # Protect from the bindep builder image use of the assemble script
@@ -96,7 +96,7 @@ function install_wheels {
     # possible to tell what is the wheel for the project and
     # what is the wheel cache.
     if [ -f setup.py ] ; then
-        python3 setup.py sdist bdist_wheel -d /output/wheels
+        $PYCMD setup.py sdist bdist_wheel -d /output/wheels
     fi
 
     # Install everything so that the wheel cache is populated with
@@ -143,7 +143,7 @@ done
 # NOTE(pabelanger): We allow users to install distro python packages of
 # libraries. This is important for projects that eventually want to produce
 # an RPM or offline install.
-python3 -m venv /tmp/venv --system-site-packages --without-pip
+$PYCMD -m venv /tmp/venv --system-site-packages --without-pip
 source /tmp/venv/bin/activate
 
 # If there is an upper-constraints.txt file in the source tree,

--- a/ansible_builder/_target_scripts/install-from-bindep
+++ b/ansible_builder/_target_scripts/install-from-bindep
@@ -30,16 +30,20 @@ if [ -z $PKGMGR ]; then
     PKGMGR=/usr/bin/dnf
     if [ -f "/usr/bin/microdnf" ]; then
         PKGMGR=/usr/bin/microdnf
-        if [ -z $PKGMGR_OPTS ]; then
-            # NOTE(pabelanger): skip install docs and weak dependencies to
-            # make smaller images. Sadly, setting these in dnf.conf don't
-            # appear to work.
-            PKGMGR_OPTS="--nodocs --setopt install_weak_deps=0"
-        fi
     fi
 fi
 
-$PKGMGR update -y $PKGMGR_OPTS
+if [ "$PKGMGR" = "/usr/bin/microdnf" ]
+then
+    if [ -z $PKGMGR_OPTS ]; then
+        # NOTE(pabelanger): skip install docs and weak dependencies to
+        # make smaller images. Sadly, setting these in dnf.conf don't
+        # appear to work.
+        PKGMGR_OPTS="--nodocs --setopt install_weak_deps=0"
+    fi
+fi
+
+$PKGMGR upgrade -y $PKGMGR_OPTS
 
 if [ -f /output/bindep/run.txt ] ; then
     PACKAGES=$(cat /output/bindep/run.txt)

--- a/ansible_builder/containerfile.py
+++ b/ansible_builder/containerfile.py
@@ -364,8 +364,6 @@ class Containerfile:
             introspect_cmd += " --write-bindep=/tmp/src/bindep.txt --write-pip=/tmp/src/requirements.txt"
 
             self.steps.append(introspect_cmd)
-            if self.definition.version >= 3:
-                self.steps.append("ENV PKGMGR=$PKGMGR")
             self.steps.append("RUN /output/scripts/assemble")
 
     def _prepare_system_runtime_deps_steps(self):

--- a/ansible_builder/ee_schema.py
+++ b/ansible_builder/ee_schema.py
@@ -300,6 +300,10 @@ schema_v3 = {
                     "description": "Disables the check for Ansible/Runner in final image",
                     "type": "boolean",
                 },
+                "package_manager_path": {
+                    "description": "Path to the system package manager to use",
+                    "type": "string",
+                }
             },
         },
     },
@@ -328,7 +332,9 @@ def validate_schema(ee_def: dict):
         raise DefinitionError(msg=e.message, path=e.absolute_schema_path)
 
     _handle_aliasing(ee_def)
-    _handle_options_defaults(ee_def)
+
+    if schema_version >= 3:
+        _handle_options_defaults(ee_def)
 
 
 def _handle_aliasing(ee_def: dict):
@@ -361,3 +367,6 @@ def _handle_options_defaults(ee_def: dict):
 
     if ee_def['options'].get('skip_ansible_check') is None:
         ee_def['options']['skip_ansible_check'] = False
+
+    if ee_def['options'].get('package_manager_path') is None:
+        ee_def['options']['package_manager_path'] = '/usr/bin/dnf'

--- a/ansible_builder/user_definition.py
+++ b/ansible_builder/user_definition.py
@@ -153,8 +153,7 @@ class UserDefinition:
 
     @property
     def options(self):
-        # Since some options have default values, the 'options' key is always available
-        return self.raw['options']
+        return self.raw.get('options', {})
 
     def get_dep_abs_path(self, entry):
         """Unique to the user EE definition, files can be referenced by either

--- a/docs/definition.rst
+++ b/docs/definition.rst
@@ -267,6 +267,12 @@ options
 This section is a dictionary that contains keywords/options that can affect
 builder runtime functionality. Valid keys for this section are:
 
+    ``package_manager_path``
+      A string with the path to the package manager (dnf or microdnf) to use.
+      The default is ``/usr/bin/dnf``. This value will be used to install a
+      python interpreter, if specified in ``dependencies``, and during the
+      build phase by the ``assemble`` script.
+
     ``skip_ansible_check``
       This boolean value controls whether or not the check for an installation
       of Ansible and Ansible Runner is performed on the final image. Set this
@@ -277,6 +283,7 @@ Example ``options`` section:
 .. code:: yaml
 
     options:
+        package_manager_path: /usr/bin/microdnf
         skip_ansible_check: True
 
 version

--- a/test/data/v3/check_ansible/ee-missing-ansible.yml
+++ b/test/data/v3/check_ansible/ee-missing-ansible.yml
@@ -1,0 +1,14 @@
+---
+version: 3
+
+images:
+  base_image:
+    name: localhost:8080/testrepo/ubi-minimal:latest
+
+dependencies:
+  ansible_runner: ansible_runner
+  python_interpreter:
+    package_name: python3
+
+options:
+  package_manager_path: /usr/bin/microdnf

--- a/test/data/v3/check_ansible/ee-missing-runner.yml
+++ b/test/data/v3/check_ansible/ee-missing-runner.yml
@@ -1,0 +1,14 @@
+---
+version: 3
+
+images:
+  base_image:
+    name: localhost:8080/testrepo/ubi-minimal:latest
+
+dependencies:
+  ansible_core: ansible_core
+  python_interpreter:
+    package_name: python3
+
+options:
+  package_manager_path: /usr/bin/microdnf

--- a/test/data/v3/check_ansible/ee-skip.yml
+++ b/test/data/v3/check_ansible/ee-skip.yml
@@ -1,0 +1,14 @@
+---
+version: 3
+
+images:
+  base_image:
+    name: localhost:8080/testrepo/ubi-minimal:latest
+
+dependencies:
+  python_interpreter:
+    package_name: python3
+
+options:
+  skip_ansible_check: True
+  package_manager_path: /usr/bin/microdnf

--- a/test/pulp_integration/test_v3.py
+++ b/test/pulp_integration/test_v3.py
@@ -1,0 +1,48 @@
+import pytest
+import subprocess
+
+
+class TestV3:
+
+    def test_ansible_check_is_skipped(self, cli, tmp_path, data_dir, podman_ee_tag):
+        """
+        Test that the check_ansible script is skipped will NOT cause build failure.
+        """
+        ee_def = data_dir / 'v3' / 'check_ansible' / 'ee-skip.yml'
+
+        result = cli(
+            f'ansible-builder build -c {tmp_path} -f {ee_def} -t {podman_ee_tag} '
+            f'--container-runtime=podman -v3'
+        )
+
+        assert result.rc == 0
+
+    def test_missing_ansible(self, cli, tmp_path, data_dir, podman_ee_tag):
+        """
+        Test that the check_ansible script will cause build failure if
+        ansible-core is not installed.
+        """
+        ee_def = data_dir / 'v3' / 'check_ansible' / 'ee-missing-ansible.yml'
+
+        with pytest.raises(subprocess.CalledProcessError) as einfo:
+            cli(
+                f'ansible-builder build -c {tmp_path} -f {ee_def} -t {podman_ee_tag} '
+                f'--container-runtime=podman -v3'
+            )
+
+        assert "ERROR - Missing Ansible installation" in einfo.value.stdout
+
+    def test_missing_runner(self, cli, tmp_path, data_dir, podman_ee_tag):
+        """
+        Test that the check_ansible script will cause build failure if
+        ansible-runner is not installed.
+        """
+        ee_def = data_dir / 'v3' / 'check_ansible' / 'ee-missing-runner.yml'
+
+        with pytest.raises(subprocess.CalledProcessError) as einfo:
+            cli(
+                f'ansible-builder build -c {tmp_path} -f {ee_def} -t {podman_ee_tag} '
+                f'--container-runtime=podman -v3'
+            )
+
+        assert "ERROR - Missing Ansible Runner installation" in einfo.value.stdout

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,9 @@ commands = pytest {posargs:test/unit}
 # Some of these tests must run serially because of a shared resource
 # (the system policy.json file).
 description = Run pulp integration tests
-commands = pytest -n 1 -m "serial" {posargs:test/pulp_integration}
+commands =
+    pytest -n 1 -m "serial" {posargs:test/pulp_integration}
+    pytest -m "not serial" {posargs:test/pulp_integration}
 
 [testenv:integration{,-py39,-py310}]
 description = Run integration tests


### PR DESCRIPTION
- Fixes bug where we incorrecty assume dnf for python interpreter install
- Add pulp tests that verify check_ansible and new pkg manager option
- Change pulp setup to pull ubi-minimal instead of ubi-micro since we need a package manager.