### PR TITLE
add container_init customization

### DIFF
--- a/ansible_builder/containerfile.py
+++ b/ansible_builder/containerfile.py
@@ -155,8 +155,15 @@ class Containerfile:
 
         self._prepare_galaxy_copy_steps()
         self._prepare_system_runtime_deps_steps()
+
+        # install init package if specified
+        # FUTURE: could move this into the pre-install wheel phase
+        if init_pip_pkg := self.definition.container_init.get('package_pip'):
+            self.steps.append(f"RUN $PYCMD -m pip install --no-cache-dir '{init_pip_pkg}'")
+
         self._insert_custom_steps('append_final')
         self._prepare_label_steps()
+        self._prepare_entrypoint_steps()
 
     def write(self):
         """
@@ -381,3 +388,9 @@ class Containerfile:
                 ),
                 "",
             ])
+
+    def _prepare_entrypoint_steps(self):
+        if ep := self.definition.container_init.get('entrypoint'):
+            self.steps.append(f"ENTRYPOINT {ep}")
+        if cmd := self.definition.container_init.get('cmd'):
+            self.steps.append(f"CMD {cmd}")

--- a/ansible_builder/ee_schema.py
+++ b/ansible_builder/ee_schema.py
@@ -303,7 +303,26 @@ schema_v3 = {
                 "package_manager_path": {
                     "description": "Path to the system package manager to use",
                     "type": "string",
-                }
+                },
+                "container_init": {
+                    "description": "Customize container startup behavior",
+                    "type": "object",
+                    "additionalProperties": False,
+                    "properties": {
+                        "package_pip": {
+                            "description": "package to install via pip for entrypoint support",
+                            "type": "string",
+                        },
+                        "entrypoint": {
+                            "description": "literal value for ENTRYPOINT Containerfile directive",
+                            "type": "string",
+                        },
+                        "cmd": {
+                            "description": "literal value for CMD Containerfile directive",
+                            "type": "string",
+                        },
+                    },
+                },
             },
         },
     },
@@ -362,11 +381,12 @@ def _handle_options_defaults(ee_def: dict):
     This method is used to set any default values for the "options" dictionary
     properties.
     """
-    if 'options' not in ee_def:
-        ee_def['options'] = {}
+    options = ee_def.setdefault('options', {})
 
-    if ee_def['options'].get('skip_ansible_check') is None:
-        ee_def['options']['skip_ansible_check'] = False
-
-    if ee_def['options'].get('package_manager_path') is None:
-        ee_def['options']['package_manager_path'] = '/usr/bin/dnf'
+    options.setdefault('skip_ansible_check', False)
+    options.setdefault('package_manager_path', '/usr/bin/dnf')
+    options.setdefault('container_init', {
+        'package_pip': 'dumb-init==1.2.5',
+        'entrypoint': '["dumb-init"]',
+        'cmd': '["bash"]',
+    })

--- a/ansible_builder/user_definition.py
+++ b/ansible_builder/user_definition.py
@@ -152,6 +152,10 @@ class UserDefinition:
         return self.raw.get('additional_build_files', [])
 
     @property
+    def container_init(self):
+        return self.raw.get('options', {}).get('container_init', {})
+
+    @property
     def options(self):
         return self.raw.get('options', {})
 


### PR DESCRIPTION
* default to pip-installed dumb-init `ENTRYPOINT`
* default to `bash` as `CMD`
* any customization cancels all defaults
